### PR TITLE
Fix for the default template selection field

### DIFF
--- a/jcodesyntaxhighlighter.xml
+++ b/jcodesyntaxhighlighter.xml
@@ -37,7 +37,6 @@
 				<field
 					name="template"
 					type="list"
-					size="30"
 					default="default"
 					label="PLG_JCODE_SYNTAX_HIGHLIGHTER_TEMPLATE_LABEL"
 					description="PLG_JCODE_SYNTAX_HIGHLIGHTER_TEMPLATE_DESC">


### PR DESCRIPTION
Fix for the default template selection field | https://github.com/Kostelano/jCode-Syntax-Highlighter/issues/26

**BEFORE / AFTER patch**

![Screenshot_1](https://user-images.githubusercontent.com/8440661/99198109-1c1edc80-279f-11eb-9b92-437a8e4aa2dd.png)
